### PR TITLE
Add .html extension to the generated chart file

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,12 @@ func main() {
 		log.WithField("err", err).Fatalf("Could not close temporary file after saving chart to it.")
 	}
 
-	open.Run("file://" + tmpfile.Name())
+	newName := tmpfile.Name() + ".html"
+	if err = os.Rename(tmpfile.Name(), newName); err != nil {
+		log.WithField("err", err).Fatalf("Could not add html extension to the temporary file.")
+	}
+
+	open.Run("file://" + newName)
 }
 
 func buildChart(i []string, o options) (bytes.Buffer, error) {


### PR DESCRIPTION
Otherwise, the open call won't work on some platforms/browsers, e.g.
Safari on Mac OS.