### PR TITLE
Pseudo-tabular data is not being correctly parsed

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -46,10 +46,21 @@ func maxLineFormat(lfs map[string]int) string {
 }
 
 func parseLineFormat(s string, sep rune, df string) string {
+	var sp []string
 	s = string(regexp.MustCompile(string(sep)+"{2,}").ReplaceAll([]byte(s), []byte(string(sep))))
-	ss := strings.Split(strings.TrimSpace(s), string(sep))
+	sp = strings.Split(strings.TrimSpace(s), string(sep))
+	// In certain cases data may appear to be tabbed, but
+	// instead there is an irregular number of spaces used
+	// as separator, rather than a tabstop. In such a case
+	// parsing above may result in a slice with a single
+	// element, not correctly parsed. In this case we want
+	// to attempt split using strings.Fields as opposed to
+	// strings.Split.
+	if len(sp) == 1 && strings.Count(sp[0], " ") > 0 {
+		sp = strings.Fields(strings.TrimSpace(s))
+	}
 	lf := ""
-	for _, sc := range ss {
+	for _, sc := range sp {
 		if _, err := strconv.ParseFloat(sc, 64); err == nil {
 			lf += "f"
 		} else if _, err := time.Parse(df, sc); err == nil && strings.TrimSpace(sc) != "" {
@@ -62,8 +73,14 @@ func parseLineFormat(s string, sep rune, df string) string {
 }
 
 func parseLine(l string, lf string, sep rune, df string) ([]float64, []string, []time.Time, error) {
+	var sp []string
 	l = string(regexp.MustCompile(string(sep)+"{2,}").ReplaceAll([]byte(l), []byte(string(sep))))
-	sp := strings.Split(strings.TrimSpace(l), string(sep))
+	sp = strings.Split(strings.TrimSpace(l), string(sep))
+	// See explanation in parseLineFormat for this seemingly
+	// unnecessary splitting code.
+	if len(sp) == 1 && strings.Count(sp[0], " ") > 0 {
+		sp = strings.Fields(strings.TrimSpace(l))
+	}
 
 	fs := []float64{}
 	ss := []string{}
@@ -74,6 +91,7 @@ func parseLine(l string, lf string, sep rune, df string) ([]float64, []string, [
 	}
 
 	for i, lfe := range lf {
+
 		s := strings.TrimSpace(sp[i])
 		switch lfe {
 		case 's':


### PR DESCRIPTION
Hi, hopefully you will consider this PR, which addresses an annoyance I ran into while dealing with a two-column dataset which was not getting properly processed.

I am not sure this is the best solution to problem which I ran into, but I am going to propose it anyway, since it does not appear to be as terrible a hack as I first thought it might be.

It may not be in line with the basic principles of the project, i.e. how much obscurity in dealing with formatting belongs in `chart` as opposed to how much is on the data provider, but I found this to be annoying myself and figured this is a better place to fix it than data.

To make this problem a bit more concrete, here's an example of what it addresses. This data appears to be tabular, but when one takes a closer look, one recognizes that it is actually a number of space characters used instead of tab, and it is not a typical replacement in this case, a typical being 4 or 8 spaces per tab.

```
$ awk '{gsub(" ", ".") ; printf("%s%s\n", $1, $2)}' dummy.dat
5.2031e+04......1964
1.6299e+09......16
3.2598e+09......261
4.8897e+09......32
6.5196e+09......19
8.1495e+09......25
9.7794e+09......13
1.1409e+10......24
1.4669e+10......10
1.6299e+10......11
2.7708e+10......1
2.9338e+10......1
3.4228e+10......8
5.5416e+10......17
5.7046e+10......4
5.8676e+10......7
6.8455e+10......5
7.8235e+10......5
7.9865e+10......1
```
Instead of above, we really wanted this:
```
$ awk '{split($1, v) ; printf("%e %d\n", v[1], $2)}' dummy.dat
5.203100e+04 1964
1.629900e+09 16
3.259800e+09 261
4.889700e+09 32
6.519600e+09 19
8.149500e+09 25
9.779400e+09 13
1.140900e+10 24
1.466900e+10 10
1.629900e+10 11
2.770800e+10 1
2.933800e+10 1
3.422800e+10 8
5.541600e+10 17
5.704600e+10 4
5.867600e+10 7
6.845500e+10 5
7.823500e+10 5
7.986500e+10 1
```